### PR TITLE
fix(parsing): handle edge case of blank strings as keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,14 +39,13 @@ exports.parse = function(buffer, offset) {
 		
 		name = readCString();
 		
-		if (type === Type.None && !name && !Object.keys(obj).length) {
-			// Root node
-			name = readCString();
-		}
-		
 		switch (type) {
 			case Type.None:
-				value = exports.parse(buffer, offset);
+				if (obj.hasOwnProperty(name)) {
+					value = obj[name];
+				} else {
+					value = exports.parse(buffer, offset);
+				}
 				break;
 			
 			case Type.String:
@@ -74,9 +73,9 @@ exports.parse = function(buffer, offset) {
 				throw new Error("Unknown KV type " + type + " encountered at offset " + offset[0]);
 		}
 		
-		if (name) {
-			obj[name] = convertObject(value);
-		}
+		if (name !== undefined) {
+	    obj[name] = convertObject(value);
+	  }
 	}
 	
 	return obj;


### PR DESCRIPTION
Fixes edge case of blank strings being keys. Not sure why this would ever happen, but heres some test data.

[meta.txt](https://github.com/DoctorMcKay/node-binarykvparser/files/759447/meta.txt)

Edit: 

Output of this specific case before:
```
> BinaryKVParser.parse(fs.readFileSync('meta.txt'))
Error: Unknown KV type 49 encountered at offset 25
```
Expected output
```
{ '':
   { 'members:numMachines': '1',
     'members:numPlayers': '1',
     'members:numSlots': '10',
     uids: '����\u0001',
     'system:netflag': 'teamlobby',
     'system:network': 'LIVE',
     'system:access': 'public',
     'game:type': 'classic',
     'game:mode': 'competitive',
     'game:mapgroupname': 'mg_de_dust2,mg_de_train,mg_de_nuke,mg_de_mirage,mg_de_cache,mg_de_overpass,mg_de_cbble',
     'game:map': 'de_dust2',
     'game:prime': '1',
     'game:nby': '1',
     'game:state': 'lobby',
     'game:search_key': 'k13565',
     'game:ark': '0',
     'game:apr': '0',
     'game:loc': 'US',
     'options:anytypemode': '0',
     'options:server': 'official' } }
```

uids is still not parsed properly, but seems to be consistent with other parsers (i.e. https://github.com/ValvePython/vdf and https://github.com/SteamRE/SteamKit/blob/master/SteamKit2/SteamKit2/Types/KeyValue.cs#L850